### PR TITLE
Added support for iCnC in the run_tests.sh script. Updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Verifying the installation
 --------------------------
 
 You can verify the installation by running the `$UCNC_ROOT/test/run_tests.sh`
-script.  The script builds, runs, and verifies the results of a few simple CnC
+script, or `$UCNC_ROOT/test/run_tests.sh --platform=icnc` if using iCnC.
+The script builds, runs, and verifies the results of a few simple CnC
 test programs. More interesting example applications can be found in the
 `$UCNC_ROOT/examples` directory. Each example has an accompanying README with
 instructions on how to build and run the application, a general explanation

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -19,7 +19,7 @@ for d in *; do
     echo ">>> Running test $d" | tee -a "$TEST_LOG"
 
     if true; then
-        cd $d && ${CNC_T:-${UCNC_T}} && ./implementSteps.sh
+        cd $d && ${CNC_T:-${UCNC_T}} "$@" && ./implementSteps.sh
     fi 2>&1 >> "$TEST_LOG"
     RES1="$?"
     EXPECTED_OUTPUT=`tail -n1 README`


### PR DESCRIPTION
This pull request fixes #4 by passing `"$@"` into `run_tests.sh`, thereby letting the user pass the platform as a parameter to `run_tests.sh`.